### PR TITLE
ext file

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -481,7 +481,7 @@ static int read(uint32_t *args) {
 #endif
  lock_release(&fileSystemLock);
 
- printf("Bytes Read: %d\n", bytes_read);
+ // printf("Bytes Read: %d\n", bytes_read);
  return bytes_read;
 }
 


### PR DESCRIPTION
```FAIL tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/filesys/extended/dir-empty-name
FAIL tests/filesys/extended/dir-mk-tree
FAIL tests/filesys/extended/dir-mkdir
FAIL tests/filesys/extended/dir-open
FAIL tests/filesys/extended/dir-over-file
FAIL tests/filesys/extended/dir-rm-cwd
pass tests/filesys/extended/dir-rm-parent
pass tests/filesys/extended/dir-rm-root
FAIL tests/filesys/extended/dir-rm-tree
FAIL tests/filesys/extended/dir-rmdir
FAIL tests/filesys/extended/dir-under-file
FAIL tests/filesys/extended/dir-vine
pass tests/filesys/extended/grow-create
FAIL tests/filesys/extended/grow-dir-lg
FAIL tests/filesys/extended/grow-file-size
FAIL tests/filesys/extended/grow-root-lg
FAIL tests/filesys/extended/grow-root-sm
FAIL tests/filesys/extended/grow-seq-lg
FAIL tests/filesys/extended/grow-seq-sm
FAIL tests/filesys/extended/grow-sparse
FAIL tests/filesys/extended/grow-tell
FAIL tests/filesys/extended/grow-two-files
FAIL tests/filesys/extended/syn-rw
FAIL tests/filesys/extended/dir-empty-name-persistence
FAIL tests/filesys/extended/dir-mk-tree-persistence
FAIL tests/filesys/extended/dir-mkdir-persistence
FAIL tests/filesys/extended/dir-open-persistence
FAIL tests/filesys/extended/dir-over-file-persistence
FAIL tests/filesys/extended/dir-rm-cwd-persistence
FAIL tests/filesys/extended/dir-rm-parent-persistence
FAIL tests/filesys/extended/dir-rm-root-persistence
FAIL tests/filesys/extended/dir-rm-tree-persistence
FAIL tests/filesys/extended/dir-rmdir-persistence
FAIL tests/filesys/extended/dir-under-file-persistence
FAIL tests/filesys/extended/dir-vine-persistence
FAIL tests/filesys/extended/grow-create-persistence
FAIL tests/filesys/extended/grow-dir-lg-persistence
FAIL tests/filesys/extended/grow-file-size-persistence
FAIL tests/filesys/extended/grow-root-lg-persistence
FAIL tests/filesys/extended/grow-root-sm-persistence
FAIL tests/filesys/extended/grow-seq-lg-persistence
FAIL tests/filesys/extended/grow-seq-sm-persistence
FAIL tests/filesys/extended/grow-sparse-persistence
FAIL tests/filesys/extended/grow-tell-persistence
FAIL tests/filesys/extended/grow-two-files-persistence
FAIL tests/filesys/extended/syn-rw-persistence
55 of 121 tests failed.
make[1]: *** [check] Error 1
make: *** [check] Error 2
